### PR TITLE
94 implement admin panel

### DIFF
--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/FieldController.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/FieldController.java
@@ -2,6 +2,7 @@ package lu.ephec.backend_projetdv2026.controller;
 
 import lu.ephec.backend_projetdv2026.dto.FieldDto;
 import lu.ephec.backend_projetdv2026.models.Field;
+import lu.ephec.backend_projetdv2026.models.Site;
 import lu.ephec.backend_projetdv2026.services.FieldService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -59,7 +60,19 @@ public class FieldController {
     }
 
     @PostMapping(produces = "application/json", consumes = "application/json")
-    public ResponseEntity<FieldDto> newField(@RequestBody Field field) {
+    public ResponseEntity<FieldDto> newField(@RequestBody FieldDto fieldDto) {
+        Field field = new Field();
+        field.setIsIndoor(fieldDto.getIsIndoor());
+        field.setIsActive(fieldDto.getIsActive() != null ? fieldDto.getIsActive() : true);
+        field.setMaintenanceFromDate(fieldDto.getMaintenanceFromDate());
+        field.setMaintenanceToDate(fieldDto.getMaintenanceToDate());
+
+        if (fieldDto.getSiteId() != null) {
+            Site site = new Site();
+            site.setSiteId(fieldDto.getSiteId());
+            field.setSite(site);
+        }
+
         Field saved = fieldService.newField(field);
         return ResponseEntity.ok(FieldDto.from(saved));
     }

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/FieldController.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/FieldController.java
@@ -6,7 +6,9 @@ import lu.ephec.backend_projetdv2026.services.FieldService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -56,5 +58,45 @@ public class FieldController {
         return ResponseEntity.ok(FieldDto.from(field));
     }
 
-}
+    @PostMapping(produces = "application/json", consumes = "application/json")
+    public ResponseEntity<FieldDto> newField(@RequestBody Field field) {
+        Field saved = fieldService.newField(field);
+        return ResponseEntity.ok(FieldDto.from(saved));
+    }
 
+    @PatchMapping(value = "/{id}", produces = "application/json", consumes = "application/json")
+    public ResponseEntity<FieldDto> updateField(@PathVariable Integer id, @RequestBody Map<String, Object> updates) {
+        if (!fieldService.fieldExists(id)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Field updateData = new Field();
+
+        if (updates.containsKey("isIndoor")) {
+            updateData.setIsIndoor((Boolean) updates.get("isIndoor"));
+        }
+
+        if (updates.containsKey("isActive")) {
+            updateData.setIsActive((Boolean) updates.get("isActive"));
+        }
+
+        if (updates.containsKey("maintenanceFromDate")) {
+            String date = (String) updates.get("maintenanceFromDate");
+            if (date != null) {
+                updateData.setMaintenanceFromDate(LocalDate.parse(date));
+            }
+        }
+
+        if (updates.containsKey("maintenanceToDate")) {
+            String date = (String) updates.get("maintenanceToDate");
+            if (date != null) {
+                updateData.setMaintenanceToDate(LocalDate.parse(date));
+            }
+        }
+
+        return fieldService.updateField(id, updateData)
+                .map(updated -> ResponseEntity.ok(FieldDto.from(updated)))
+                .orElse(ResponseEntity.badRequest().build());
+    }
+
+}

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/SiteController.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/SiteController.java
@@ -9,9 +9,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RestController
@@ -76,5 +78,64 @@ public class SiteController {
         return ResponseEntity.ok(simplified);
     }
 
+    @PostMapping(produces = "application/json", consumes = "application/json")
+    public ResponseEntity<SiteDto> newSite(@RequestBody Site site) {
+        logger.info("[SITE CONTROLLER] Creating new site");
+        Site saved = siteService.newSite(site);
+
+        List<?> sessions = null;
+        try {
+            sessions = siteService.fetchSessionTimesForSite(saved.getSiteId());
+        } catch (Exception ex) {
+            logger.warn("[SITE CONTROLLER] Failed to fetch sessions for site {} — leaving sessions=null", saved.getSiteId(), ex);
+        }
+
+        return ResponseEntity.ok(SiteDto.from(saved, sessions));
+    }
+
+    @PatchMapping(value = "/{siteId}", produces = "application/json")
+    public ResponseEntity<SiteDto> updateSite(@PathVariable Integer siteId, @RequestBody Map<String, Object> updates) {
+        logger.info("[SITE CONTROLLER] Updating site with id={}", siteId);
+
+        Optional<Site> siteOpt = siteService.fetchById(siteId);
+        if (siteOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Site updateData = new Site();
+
+        if (updates.containsKey("siteName")) {
+            updateData.setName((String) updates.get("siteName"));
+        }
+
+        if (updates.containsKey("siteAddress")) {
+            updateData.setAddress((String) updates.get("siteAddress"));
+        }
+
+        if (updates.containsKey("openingTime")) {
+            logger.warn("[SITE CONTROLLER] Received update for openingTime, process will have to recalculate sessions.");
+            updateData.setOpeningTime((LocalTime) updates.get("openingTime"));
+        }
+
+        if (updates.containsKey("closingTime")) {
+            updateData.setClosingTime((LocalTime) updates.get("closingTime"));
+        }
+
+        if (updates.containsKey("isActive")) {
+            updateData.setIsActive((Boolean) updates.get("isActive"));
+        }
+
+        return siteService.updateSite(siteId, updateData)
+                .map(updated -> {
+                    List<?> sessions = null;
+                    try {
+                        sessions = siteService.fetchSessionTimesForSite(updated.getSiteId());
+                    } catch (Exception ex) {
+                        logger.warn("[SITE CONTROLLER] Failed to fetch sessions for site {} — leaving sessions=null", updated.getSiteId(), ex);
+                    }
+                    return ResponseEntity.ok(SiteDto.from(updated, sessions));
+                })
+                .orElse(ResponseEntity.badRequest().build());
+    }
 }
 

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/SiteController.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/SiteController.java
@@ -79,8 +79,19 @@ public class SiteController {
     }
 
     @PostMapping(produces = "application/json", consumes = "application/json")
-    public ResponseEntity<SiteDto> newSite(@RequestBody Site site) {
+    public ResponseEntity<SiteDto> newSite(@RequestBody SiteDto siteDto) {
         logger.info("[SITE CONTROLLER] Creating new site");
+        Site site = new Site();
+        site.setName(siteDto.getName());
+        site.setAddress(siteDto.getAddress());
+        if (siteDto.getOpeningTime() != null) {
+            site.setOpeningTime(siteDto.getOpeningTime());
+        }
+        if (siteDto.getClosingTime() != null) {
+            site.setClosingTime(siteDto.getClosingTime());
+        }
+        site.setIsActive(siteDto.getIsActive() != null ? siteDto.getIsActive() : true);
+
         Site saved = siteService.newSite(site);
 
         List<?> sessions = null;
@@ -114,11 +125,24 @@ public class SiteController {
 
         if (updates.containsKey("openingTime")) {
             logger.warn("[SITE CONTROLLER] Received update for openingTime, process will have to recalculate sessions.");
-            updateData.setOpeningTime((LocalTime) updates.get("openingTime"));
+            Object val = updates.get("openingTime");
+            if (val instanceof String) {
+                updateData.setOpeningTime(LocalTime.parse((String) val));
+            } else if (val instanceof Map) {
+                // If somehow it's still sent as an object
+                Map<String, Integer> m = (Map<String, Integer>) val;
+                updateData.setOpeningTime(LocalTime.of(m.getOrDefault("hour", 0), m.getOrDefault("minute", 0)));
+            }
         }
 
         if (updates.containsKey("closingTime")) {
-            updateData.setClosingTime((LocalTime) updates.get("closingTime"));
+            Object val = updates.get("closingTime");
+            if (val instanceof String) {
+                updateData.setClosingTime(LocalTime.parse((String) val));
+            } else if (val instanceof Map) {
+                Map<String, Integer> m = (Map<String, Integer>) val;
+                updateData.setClosingTime(LocalTime.of(m.getOrDefault("hour", 0), m.getOrDefault("minute", 0)));
+            }
         }
 
         if (updates.containsKey("isActive")) {

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/UserController.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/UserController.java
@@ -180,8 +180,6 @@ public class UserController {
             return ResponseEntity.notFound().build();
         }
 
-        User existingUser = userOpt.get();
-
         // Map updates to a partial User object for the service
         User updateData = new User();
 

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/UserController.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/controller/UserController.java
@@ -64,6 +64,14 @@ public class UserController {
         return ResponseEntity.ok(responses);
     }
 
+    @GetMapping(value = "/siteusers", produces = "application/json")
+    public ResponseEntity<List<UserProfileDto>> getUsersForSite(@RequestParam("siteId") Integer siteId){
+        List<UserProfileDto> responses = userService.fetchBySite(siteId).stream()
+                .map(this::fetchUserProfile)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
     // Single endpoint to fetch by either email or matricule to avoid ambiguous mappings when both
     // routes would match the same path segment. If the identifier contains '@' it is treated as an email.
     @GetMapping(value = "/{identifier}", produces = "application/json")

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/exception/ApiErrorResponse.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/exception/ApiErrorResponse.java
@@ -1,0 +1,18 @@
+package lu.ephec.backend_projetdv2026.exception;
+
+import java.time.LocalDateTime;
+
+/**
+ * Standard error payload returned by {@link GlobalExceptionHandler}.
+ *
+ * Keeping this strongly typed (instead of Map<String, Object>) helps Springdoc generate /v3/api-docs
+ * reliably.
+ */
+public record ApiErrorResponse(
+        LocalDateTime timestamp,
+        int status,
+        String message,
+        String path
+) {
+}
+

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package lu.ephec.backend_projetdv2026.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", ex.getStatusCode().value());
+
+        // We only expose the 'reason' message for controlled validation errors (400 Bad Request, 409 Conflict)
+        // This prevents leaking sensitive information from internal server errors (500)
+        boolean isValidationError = ex.getStatusCode() == HttpStatus.BAD_REQUEST || ex.getStatusCode() == HttpStatus.CONFLICT;
+
+        if (isValidationError) {
+            body.put("message", ex.getReason());
+        } else {
+            body.put("message", "An unexpected error occurred");
+        }
+
+        return new ResponseEntity<>(body, ex.getStatusCode());
+    }
+
+    // Optional: catch all other exceptions to ensure no internal messages leak
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleAllExceptions(Exception ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        body.put("message", "An unexpected error occurred");
+
+        return new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/exception/GlobalExceptionHandler.java
@@ -1,46 +1,48 @@
 package lu.ephec.backend_projetdv2026.exception;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
 
-@ControllerAdvice
+import java.time.LocalDateTime;
+
+@RestControllerAdvice(basePackages = "lu.ephec.backend_projetdv2026.controller")
+@Hidden
 public class GlobalExceptionHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException ex) {
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("timestamp", LocalDateTime.now());
-        body.put("status", ex.getStatusCode().value());
+    public ResponseEntity<ApiErrorResponse> handleResponseStatusException(ResponseStatusException ex, HttpServletRequest request) {
+        int status = ex.getStatusCode().value();
 
         // We only expose the 'reason' message for controlled validation errors (400 Bad Request, 409 Conflict)
         // This prevents leaking sensitive information from internal server errors (500)
         boolean isValidationError = ex.getStatusCode() == HttpStatus.BAD_REQUEST || ex.getStatusCode() == HttpStatus.CONFLICT;
 
-        if (isValidationError) {
-            body.put("message", ex.getReason());
-        } else {
-            body.put("message", "An unexpected error occurred");
-        }
-
-        return new ResponseEntity<>(body, ex.getStatusCode());
+        String message = isValidationError ? ex.getReason() : "An unexpected error occurred";
+        ApiErrorResponse body = new ApiErrorResponse(LocalDateTime.now(), status, message, request.getRequestURI());
+        return ResponseEntity.status(ex.getStatusCode()).body(body);
     }
 
     // Optional: catch all other exceptions to ensure no internal messages leak
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleAllExceptions(Exception ex) {
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("timestamp", LocalDateTime.now());
-        body.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
-        body.put("message", "An unexpected error occurred");
-
-        return new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR);
+    public ResponseEntity<ApiErrorResponse> handleAllExceptions(Exception ex, HttpServletRequest request) {
+        logger.error("[GlobalExceptionHandler] Unhandled exception on {}", request.getRequestURI(), ex);
+        ApiErrorResponse body = new ApiErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "An unexpected error occurred",
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
     }
 }
 

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/services/FieldService.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/services/FieldService.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -168,14 +169,22 @@ public class FieldService {
             }
 
             if (updateData.getMaintenanceFromDate() != null) {
-                field.setMaintenanceFromDate(updateData.getMaintenanceFromDate());
+                if (updateData.getMaintenanceFromDate().equals(java.time.LocalDate.of(1970, 1, 1))) {
+                    field.setMaintenanceFromDate(null);
+                } else {
+                    field.setMaintenanceFromDate(updateData.getMaintenanceFromDate());
+                }
             }
 
             if (updateData.getMaintenanceToDate() != null) {
-                field.setMaintenanceToDate(updateData.getMaintenanceToDate());
+                if (updateData.getMaintenanceToDate().equals(java.time.LocalDate.of(1970, 1, 1))) {
+                    field.setMaintenanceToDate(null);
+                } else {
+                    field.setMaintenanceToDate(updateData.getMaintenanceToDate());
+                }
             }
 
-            if  (updateData.getMaintenanceFromDate() != null && updateData.getMaintenanceToDate() != null) {
+            if  (field.getMaintenanceFromDate() != null && field.getMaintenanceToDate() != null) {
                 ValidationBoiler.verifyDatesValid(field.getMaintenanceFromDate(), field.getMaintenanceToDate(), "Maintenance From / To Date");
             }
 

--- a/backend/src/main/java/lu/ephec/backend_projetdv2026/services/UserService.java
+++ b/backend/src/main/java/lu/ephec/backend_projetdv2026/services/UserService.java
@@ -1,9 +1,6 @@
 package lu.ephec.backend_projetdv2026.services;
 import jakarta.transaction.Transactional;
-import lu.ephec.backend_projetdv2026.models.EnumUserRolesType;
-import lu.ephec.backend_projetdv2026.models.MatchPayments;
-import lu.ephec.backend_projetdv2026.models.User;
-import lu.ephec.backend_projetdv2026.models.UserPenalties;
+import lu.ephec.backend_projetdv2026.models.*;
 import lu.ephec.backend_projetdv2026.repo.*;
 import lu.ephec.backend_projetdv2026.services.validation.MatriculeHandler;
 import lu.ephec.backend_projetdv2026.services.validation.ValidationBoiler;
@@ -25,10 +22,11 @@ public class UserService {
     private final JPAUserAccountsRepo jpaUserAccountsRepo;
     private final JPAMatchPaymentsRepo jpaMatchPaymentsRepo;
     private final JPAUserSiteRepo jpaUserSiteRepo;
+    private final JPASiteRepo jpaSiteRepo;
     private static final Logger logger = LoggerFactory.getLogger(UserService.class);
 
     // InjDep Interface User + Penalties
-    public UserService(JPAUserRepo jpaUserRepo, JPAUserPenaltiesRepo jpaUserPenaltiesRepo, MigrateUserDESTRUCTIVE migrateUser, PaymentService paymentService, JPAUserAccountsRepo jpaUserAccountsRepo, JPAMatchPaymentsRepo jpaMatchPaymentsRepo, JPAUserSiteRepo jpaUserSiteRepo) {
+    public UserService(JPAUserRepo jpaUserRepo, JPAUserPenaltiesRepo jpaUserPenaltiesRepo, MigrateUserDESTRUCTIVE migrateUser, PaymentService paymentService, JPAUserAccountsRepo jpaUserAccountsRepo, JPAMatchPaymentsRepo jpaMatchPaymentsRepo, JPAUserSiteRepo jpaUserSiteRepo, JPASiteRepo jpaSiteRepo) {
         this.jpaUserRepo = jpaUserRepo;
         this.jpaUserPenaltiesRepo = jpaUserPenaltiesRepo;
         this.migrateUser = migrateUser;
@@ -36,6 +34,7 @@ public class UserService {
         this.jpaUserAccountsRepo = jpaUserAccountsRepo;
         this.jpaMatchPaymentsRepo = jpaMatchPaymentsRepo;
         this.jpaUserSiteRepo = jpaUserSiteRepo;
+        this.jpaSiteRepo = jpaSiteRepo;
     }
 
     ////////////USER OPERATIONS
@@ -132,8 +131,21 @@ public class UserService {
         return jpaUserRepo.findByFirstNameIgnoreCaseOrLastNameIgnoreCase(gname, gname);
     }
 
-    //GET All Users
+    //GET All Users -- FOR SUPER ADMINS
     public List<User> fetchAll() { return jpaUserRepo.findAll(); }
+
+    // FETCH ALL USER FOR SITE
+    public List<User> fetchBySite(Integer siteId) {
+        ValidationBoiler.verifyNotNull(siteId, "Site ID");
+        ValidationBoiler.verifyExists(jpaSiteRepo.existsById(siteId), "Site", siteId);
+
+        List<UsersSites> links = jpaUserSiteRepo.findBySite_SiteId(siteId);
+        List<User> users = new java.util.ArrayList<>();
+        for (UsersSites link : links) {
+            users.add(link.getUser());
+        }
+        return users;
+    }
 
     //GET Users by ROLE ID
     public List<User> fetchByRoleId(Short roleId) {

--- a/frontend/src/app/api/api/fieldController.service.ts
+++ b/frontend/src/app/api/api/fieldController.service.ts
@@ -17,8 +17,6 @@ import { Observable }                                        from 'rxjs';
 import { OpenApiHttpParams, QueryParamStyle } from '../query.params';
 
 // @ts-ignore
-import { Field } from '../model/field';
-// @ts-ignore
 import { FieldDto } from '../model/fieldDto';
 
 // @ts-ignore
@@ -310,17 +308,17 @@ export class FieldControllerService extends BaseService {
 
     /**
      * @endpoint post /api/fields
-     * @param field 
+     * @param fieldDto 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public newField(field: Field, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<FieldDto>;
-    public newField(field: Field, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<FieldDto>>;
-    public newField(field: Field, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<FieldDto>>;
-    public newField(field: Field, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
-        if (field === null || field === undefined) {
-            throw new Error('Required parameter field was null or undefined when calling newField.');
+    public newField(fieldDto: FieldDto, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<FieldDto>;
+    public newField(fieldDto: FieldDto, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<FieldDto>>;
+    public newField(fieldDto: FieldDto, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<FieldDto>>;
+    public newField(fieldDto: FieldDto, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (fieldDto === null || fieldDto === undefined) {
+            throw new Error('Required parameter fieldDto was null or undefined when calling newField.');
         }
 
         let localVarHeaders = this.defaultHeaders;
@@ -362,7 +360,7 @@ export class FieldControllerService extends BaseService {
         return this.httpClient.request<FieldDto>('post', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
-                body: field,
+                body: fieldDto,
                 responseType: <any>responseType_,
                 ...(withCredentials ? { withCredentials } : {}),
                 headers: localVarHeaders,

--- a/frontend/src/app/api/api/fieldController.service.ts
+++ b/frontend/src/app/api/api/fieldController.service.ts
@@ -17,6 +17,8 @@ import { Observable }                                        from 'rxjs';
 import { OpenApiHttpParams, QueryParamStyle } from '../query.params';
 
 // @ts-ignore
+import { Field } from '../model/field';
+// @ts-ignore
 import { FieldDto } from '../model/fieldDto';
 
 // @ts-ignore
@@ -296,6 +298,140 @@ export class FieldControllerService extends BaseService {
         return this.httpClient.request<Array<FieldDto>>('get', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @endpoint post /api/fields
+     * @param field 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public newField(field: Field, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<FieldDto>;
+    public newField(field: Field, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<FieldDto>>;
+    public newField(field: Field, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<FieldDto>>;
+    public newField(field: Field, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (field === null || field === undefined) {
+            throw new Error('Required parameter field was null or undefined when calling newField.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'application/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'application/json'
+        ];
+        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+        if (httpContentTypeSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/fields`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<FieldDto>('post', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: field,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @endpoint patch /api/fields/{id}
+     * @param id 
+     * @param requestBody 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public updateField(id: number, requestBody: { [key: string]: object; }, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<FieldDto>;
+    public updateField(id: number, requestBody: { [key: string]: object; }, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<FieldDto>>;
+    public updateField(id: number, requestBody: { [key: string]: object; }, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<FieldDto>>;
+    public updateField(id: number, requestBody: { [key: string]: object; }, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling updateField.');
+        }
+        if (requestBody === null || requestBody === undefined) {
+            throw new Error('Required parameter requestBody was null or undefined when calling updateField.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'application/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'application/json'
+        ];
+        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+        if (httpContentTypeSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/fields/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<FieldDto>('patch', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: requestBody,
                 responseType: <any>responseType_,
                 ...(withCredentials ? { withCredentials } : {}),
                 headers: localVarHeaders,

--- a/frontend/src/app/api/api/siteController.service.ts
+++ b/frontend/src/app/api/api/siteController.service.ts
@@ -17,6 +17,8 @@ import { Observable }                                        from 'rxjs';
 import { OpenApiHttpParams, QueryParamStyle } from '../query.params';
 
 // @ts-ignore
+import { Site } from '../model/site';
+// @ts-ignore
 import { SiteDto } from '../model/siteDto';
 
 // @ts-ignore
@@ -199,6 +201,140 @@ export class SiteControllerService extends BaseService {
         return this.httpClient.request<SiteDto>('get', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @endpoint post /api/sites
+     * @param site 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public newSite(site: Site, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDto>;
+    public newSite(site: Site, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDto>>;
+    public newSite(site: Site, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDto>>;
+    public newSite(site: Site, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (site === null || site === undefined) {
+            throw new Error('Required parameter site was null or undefined when calling newSite.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'application/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'application/json'
+        ];
+        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+        if (httpContentTypeSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/sites`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<SiteDto>('post', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: site,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @endpoint patch /api/sites/{siteId}
+     * @param siteId 
+     * @param requestBody 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public updateSite(siteId: number, requestBody: { [key: string]: object; }, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDto>;
+    public updateSite(siteId: number, requestBody: { [key: string]: object; }, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDto>>;
+    public updateSite(siteId: number, requestBody: { [key: string]: object; }, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDto>>;
+    public updateSite(siteId: number, requestBody: { [key: string]: object; }, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (siteId === null || siteId === undefined) {
+            throw new Error('Required parameter siteId was null or undefined when calling updateSite.');
+        }
+        if (requestBody === null || requestBody === undefined) {
+            throw new Error('Required parameter requestBody was null or undefined when calling updateSite.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'application/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'application/json'
+        ];
+        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+        if (httpContentTypeSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/sites/${this.configuration.encodeParam({name: "siteId", value: siteId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<SiteDto>('patch', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: requestBody,
                 responseType: <any>responseType_,
                 ...(withCredentials ? { withCredentials } : {}),
                 headers: localVarHeaders,

--- a/frontend/src/app/api/api/siteController.service.ts
+++ b/frontend/src/app/api/api/siteController.service.ts
@@ -17,8 +17,6 @@ import { Observable }                                        from 'rxjs';
 import { OpenApiHttpParams, QueryParamStyle } from '../query.params';
 
 // @ts-ignore
-import { Site } from '../model/site';
-// @ts-ignore
 import { SiteDto } from '../model/siteDto';
 
 // @ts-ignore
@@ -213,17 +211,17 @@ export class SiteControllerService extends BaseService {
 
     /**
      * @endpoint post /api/sites
-     * @param site 
+     * @param siteDto 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public newSite(site: Site, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDto>;
-    public newSite(site: Site, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDto>>;
-    public newSite(site: Site, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDto>>;
-    public newSite(site: Site, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
-        if (site === null || site === undefined) {
-            throw new Error('Required parameter site was null or undefined when calling newSite.');
+    public newSite(siteDto: SiteDto, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDto>;
+    public newSite(siteDto: SiteDto, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDto>>;
+    public newSite(siteDto: SiteDto, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDto>>;
+    public newSite(siteDto: SiteDto, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (siteDto === null || siteDto === undefined) {
+            throw new Error('Required parameter siteDto was null or undefined when calling newSite.');
         }
 
         let localVarHeaders = this.defaultHeaders;
@@ -265,7 +263,7 @@ export class SiteControllerService extends BaseService {
         return this.httpClient.request<SiteDto>('post', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
-                body: site,
+                body: siteDto,
                 responseType: <any>responseType_,
                 ...(withCredentials ? { withCredentials } : {}),
                 headers: localVarHeaders,

--- a/frontend/src/app/api/api/userController.service.ts
+++ b/frontend/src/app/api/api/userController.service.ts
@@ -252,6 +252,73 @@ export class UserControllerService extends BaseService {
     }
 
     /**
+     * @endpoint get /api/users/siteusers
+     * @param siteId 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public getUsersForSite(siteId: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Array<UserProfileDto>>;
+    public getUsersForSite(siteId: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Array<UserProfileDto>>>;
+    public getUsersForSite(siteId: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Array<UserProfileDto>>>;
+    public getUsersForSite(siteId: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (siteId === null || siteId === undefined) {
+            throw new Error('Required parameter siteId was null or undefined when calling getUsersForSite.');
+        }
+
+        let localVarQueryParameters = new OpenApiHttpParams(this.encoder);
+
+        localVarQueryParameters = this.addToHttpParams(
+            localVarQueryParameters,
+            'siteId',
+            <any>siteId,
+            QueryParamStyle.Form,
+            true,
+        );
+
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'application/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/users/siteusers`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<Array<UserProfileDto>>('get', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                params: localVarQueryParameters.toHttpParams(),
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * @endpoint patch /api/users/{userId}
      * @param userId 
      * @param requestBody 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { JoinPublicMatch } from './layout/content/pages/join-public-match/join-p
 import { MyMatches } from './layout/content/pages/my-matches/my-matches';
 import { SettingsComponent } from './layout/content/pages/settings/settings';
 import { MyProfile } from './layout/content/pages/my-profile/my-profile';
+import { AdminComponent} from './layout/content/pages/admin-panel/admin';
 
 export const authGuard: CanActivateFn = (route, state) => {
   const authService = inject(AuthService);
@@ -68,6 +69,14 @@ export const authGuard: CanActivateFn = (route, state) => {
           return router.createUrlTree(['/home', currentMatricule]);
         }
 
+        // Protect admin block from non-admins, and settings from admins
+        if (url.includes('admin') && !isAdmin) {
+          return router.createUrlTree(['/home', currentMatricule]);
+        }
+        if (url.includes('settings') && isAdmin) {
+          return router.createUrlTree(['/home', currentMatricule, 'admin']);
+        }
+
         // If trying to access create_pmatch manually and the user has a restriction
         // (active penalty or debt), redirect to home and set a query param that will
         // trigger a popup on the UI.
@@ -100,6 +109,7 @@ export const routes: Routes = [
   { path: 'home/:userId/join_public', component: JoinPublicMatch, canActivate: [authGuard] },
   { path: 'home/:userId/my_matches', component: MyMatches, canActivate: [authGuard] },
   { path: 'home/:userId/settings', component: SettingsComponent, canActivate: [authGuard] },
+  { path: 'home/:userId/admin', component: AdminComponent, canActivate: [authGuard] },
   { path: 'home/:userId/me', component: MyProfile, canActivate: [authGuard] },
   { path: 'home/:userId', component: HomeAccount, canActivate: [authGuard] },
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/layout/content/nav-menu/nav-menu.cy.ts
+++ b/frontend/src/app/layout/content/nav-menu/nav-menu.cy.ts
@@ -71,7 +71,7 @@ describe('NavMenu Component', () => {
       cy.contains('Mes Invitations').should('be.visible');
       cy.contains('Rejoindre Match Public').should('be.visible');
       cy.contains('Créer Match Privé').should('be.visible');
-      cy.contains('Reglages').should('be.visible');
+      cy.contains('Réglages').should('be.visible');
       cy.contains('Se Déconnecter').should('be.visible');
     });
   });
@@ -90,8 +90,8 @@ describe('NavMenu Component', () => {
       cy.contains(/Mes Invitations/i).should('not.exist');
       cy.contains(/Rejoindre Match Public/i).should('not.exist');
 
-      // Specifically check that "Reglages" (user version) is not present
-      cy.contains(/Reglages/i).should('not.exist');
+      // Specifically check that "Réglages" (user version) is not present
+      cy.contains(/Réglages/i).should('not.exist');
     });
   });
 

--- a/frontend/src/app/layout/content/nav-menu/nav-menu.html
+++ b/frontend/src/app/layout/content/nav-menu/nav-menu.html
@@ -15,11 +15,9 @@
             <a [routerLink]="currentMatricule ? ['/home', currentMatricule, 'invites'] : ['/home']" (click)="close()" class="hover:text-blue-600 flex font-bold items-center gap-3">✉️ MES INVITATIONS</a>
             <a href="#" (click)="$event.preventDefault(); goJoinPublic(); close()" class="hover:text-blue-600 flex font-bold items-center gap-3">➕ MATCH PUBLIC</a>
           }
-          <a href="#" (click)="$event.preventDefault(); goCreatePmatch() ; close()" class="hover:text-blue-600 flex font-bold items-center gap-3">
-            ⭐ {{ isAdmin ? 'Créer Match Public' : 'Créer Match Privé' }}
-          </a>
-          <a [routerLink]="currentMatricule ? ['/home', currentMatricule, isAdmin ? 'admin' : 'settings'] : ['/home']" (click)="close()" class="hover:text-blue-600 flex font-bold items-center gap-3">🛠️ {{ isAdmin ? 'PANNEAU ADMIN' : 'REGLAGES' }}</a>
-          <button (click)="onLogout()" class="mt-4 text-left hover:text-red-500 flex font-bold items-center gap-3 p-1">⏻ SE DECONNECTER</button>
+          <a href="#" (click)="$event.preventDefault(); goCreatePmatch()" class="hover:text-blue-600 flex font-bold items-center gap-3">⭐ {{ isAdmin ? 'CRÉER PUBLIC' : 'CRÉER PRIVÉ' }}</a>
+          <a [routerLink]="currentMatricule ? ['/home', currentMatricule, isAdmin ? 'admin' : 'settings'] : ['/home']" (click)="close()" class="hover:text-blue-600 flex font-bold items-center gap-3">🛠️ {{ isAdmin ? 'PANNEAU ADM' : 'RÉGLAGES' }}</a>
+          <button (click)="onLogout()" class="mt-4 text-left hover:text-red-500 flex font-bold items-center gap-3 p-1">⏻ SE DÉCONNECTER</button>
         </nav>
       </div>
     </div>
@@ -35,7 +33,7 @@
         <a href="#" (click)="$event.preventDefault(); goJoinPublic()" class="hover:text-blue-600 flex items-center gap-3">➕ Rejoindre Match Public</a>
       }
       <a href="#" (click)="$event.preventDefault(); goCreatePmatch()" class="hover:text-blue-600 flex items-center gap-3">⭐ {{ isAdmin ? 'Créer Match Public' : 'Créer Match Privé' }}</a>
-      <a [routerLink]="currentMatricule ? ['/home', currentMatricule, isAdmin ? 'admin' : 'settings'] : ['/home']" class="hover:text-blue-600 flex items-center gap-3">🛠️ {{ isAdmin ? 'Panneau Admin' : 'Reglages' }}</a>
+      <a [routerLink]="currentMatricule ? ['/home', currentMatricule, isAdmin ? 'admin' : 'settings'] : ['/home']" class="hover:text-blue-600 flex items-center gap-3">🛠️ {{ isAdmin ? 'Panneau Admin' : 'Réglages' }}</a>
       <button (click)="onLogout()" class="hover:text-red-500 flex items-center gap-3 p-1">⏻ Se Déconnecter</button>
     </nav>
   </aside>

--- a/frontend/src/app/layout/content/nav-menu/nav-menu.html
+++ b/frontend/src/app/layout/content/nav-menu/nav-menu.html
@@ -18,7 +18,7 @@
           <a href="#" (click)="$event.preventDefault(); goCreatePmatch() ; close()" class="hover:text-blue-600 flex font-bold items-center gap-3">
             ⭐ {{ isAdmin ? 'Créer Match Public' : 'Créer Match Privé' }}
           </a>
-          <a [routerLink]="currentMatricule ? ['/home', currentMatricule, 'settings'] : ['/home']" (click)="close()" class="hover:text-blue-600 flex font-bold items-center gap-3">🛠️ {{ isAdmin ? 'PANNEAU ADMIN' : 'REGLAGES' }}</a>
+          <a [routerLink]="currentMatricule ? ['/home', currentMatricule, isAdmin ? 'admin' : 'settings'] : ['/home']" (click)="close()" class="hover:text-blue-600 flex font-bold items-center gap-3">🛠️ {{ isAdmin ? 'PANNEAU ADMIN' : 'REGLAGES' }}</a>
           <button (click)="onLogout()" class="mt-4 text-left hover:text-red-500 flex font-bold items-center gap-3 p-1">⏻ SE DECONNECTER</button>
         </nav>
       </div>
@@ -35,7 +35,7 @@
         <a href="#" (click)="$event.preventDefault(); goJoinPublic()" class="hover:text-blue-600 flex items-center gap-3">➕ Rejoindre Match Public</a>
       }
       <a href="#" (click)="$event.preventDefault(); goCreatePmatch()" class="hover:text-blue-600 flex items-center gap-3">⭐ {{ isAdmin ? 'Créer Match Public' : 'Créer Match Privé' }}</a>
-      <a [routerLink]="currentMatricule ? ['/home', currentMatricule, 'settings'] : ['/home']" class="hover:text-blue-600 flex items-center gap-3">🛠️ {{ isAdmin ? 'Panneau Admin' : 'Reglages' }}</a>
+      <a [routerLink]="currentMatricule ? ['/home', currentMatricule, isAdmin ? 'admin' : 'settings'] : ['/home']" class="hover:text-blue-600 flex items-center gap-3">🛠️ {{ isAdmin ? 'Panneau Admin' : 'Reglages' }}</a>
       <button (click)="onLogout()" class="hover:text-red-500 flex items-center gap-3 p-1">⏻ Se Déconnecter</button>
     </nav>
   </aside>

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -53,7 +53,7 @@
               </div>
               <div>
                 <label class="block text-xs font-semibold text-gray-600 mb-1">Statut</label>
-                <select [(ngModel)]="userFilters.isActive" class="border border-gray-300 rounded p-1.5 text-sm min-w-24 focus:ring-blue-500">
+                <select [ngModel]="userFilters.isActive" (ngModelChange)="userFilters.isActive = $event" class="border border-gray-300 rounded p-1.5 text-sm min-w-24 focus:ring-blue-500">
                   <option value="">Tous</option>
                   <option value="true">Actif</option>
                   <option value="false">Inactif</option>

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -191,7 +191,7 @@
                             <span class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded ml-2 shadow-sm">{{ field.fieldType || field.type }}</span>
                           </div>
                           <button class="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded text-xs transition-colors shadow-sm">
-                            Désactiver
+                            Planifier une maintenance
                           </button>
                         </div>
                       }

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -332,6 +332,12 @@
           </div>
         </div>
 
+        @if (siteFormError) {
+          <div class="mt-4 p-3 bg-red-100 text-red-800 text-sm rounded-lg border border-red-200">
+            {{ siteFormError }}
+          </div>
+        }
+
         <div class="mt-6">
           <button type="submit" [disabled]="siteForm.invalid || isSubmittingSite" class="w-full bg-blue-600 text-white font-bold py-3 rounded-full shadow-lg hover:bg-blue-700 disabled:opacity-50 transition-colors">
             {{ isSubmittingSite ? 'CRÉATION...' : 'CRÉER LE SITE' }}
@@ -371,4 +377,3 @@
     </div>
   </div>
 }
-

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -197,7 +197,7 @@
                             <div class="flex items-center gap-2">
                               <span class="font-bold text-gray-700">Terrain #{{ field.fieldId || field.id }}</span>
                               <span class="bg-blue-100 text-blue-800 text-xs px-2 py-0.5 rounded font-semibold shadow-sm">
-                                {{ field.isIndoor ? 'Indoor' : 'Outdoor' }}
+                                {{ field.isIndoor ? 'Intérieur' : 'Extérieur' }}
                               </span>
                               @if (field.maintenanceFromDate || field.maintenanceToDate) {
                                 <span class="bg-orange-100 text-orange-800 text-xs px-2 py-0.5 rounded font-semibold animate-pulse">
@@ -362,11 +362,11 @@
         <div class="flex justify-around items-center">
           <label class="flex items-center gap-2 cursor-pointer group">
             <input type="radio" [value]="true" formControlName="isIndoor" class="w-5 h-5 text-blue-600 border-gray-300 focus:ring-blue-500">
-            <span class="text-lg font-medium group-hover:text-blue-600 transition-colors">Indoor</span>
+            <span class="text-lg font-medium group-hover:text-blue-600 transition-colors">Intérieur</span>
           </label>
           <label class="flex items-center gap-2 cursor-pointer group">
             <input type="radio" [value]="false" formControlName="isIndoor" class="w-5 h-5 text-blue-600 border-gray-300 focus:ring-blue-500">
-            <span class="text-lg font-medium group-hover:text-blue-600 transition-colors">Outdoor</span>
+            <span class="text-lg font-medium group-hover:text-blue-600 transition-colors">Extérieur</span>
           </label>
         </div>
 

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -149,7 +149,7 @@
 
         @if (activeTab === 'sites') {
           <div class="mb-4 flex flex-row-reverse">
-            <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm transition-colors">Ajouter un site</button>
+            <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm transition-colors shadow-sm" (click)="openSiteForm()">+ Nouveau Site</button>
           </div>
           <div class="space-y-4">
             @for (site of sites; track site.siteId || site.id) {
@@ -163,10 +163,18 @@
                     <span class="text-sm font-normal text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">
                       {{ fieldsBySiteId[site.siteId || site.id]?.length || 0 }} terrains
                     </span>
+                    <span class="px-2 py-1 rounded-full text-xs font-semibold"
+                          [class.bg-green-100]="site.isActive" [class.text-green-800]="site.isActive"
+                          [class.bg-red-100]="!site.isActive" [class.text-red-800]="!site.isActive">
+                      {{ site.isActive ? 'Actif' : 'Inactif' }}
+                    </span>
                   </span>
                   <div class="flex gap-2">
-                    <button class="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded text-sm transition-colors" (click)="$event.stopPropagation()">
-                      Désactiver
+                    <button class="text-white px-3 py-1 rounded text-sm transition-colors shadow-sm"
+                            [class.bg-orange-500]="site.isActive" [class.hover:bg-orange-600]="site.isActive"
+                            [class.bg-green-600]="!site.isActive" [class.hover:bg-green-700]="!site.isActive"
+                            (click)="$event.stopPropagation(); toggleSiteActiveStatus(site)">
+                      {{ site.isActive ? 'Désactiver' : 'Réactiver' }}
                     </button>
                     <button class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded text-sm transition-colors">
                       {{ expandedSiteId === (site.siteId || site.id) ? '▲' : '▼' }}
@@ -178,21 +186,36 @@
                   <div class="mt-4 border-t pt-4">
                     <div class="flex justify-between items-center mb-3">
                       <h4 class="font-semibold text-md text-gray-700">Terrains pour {{ site.name || site.siteName }}</h4>
-                      <button class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-xs transition-colors">
+                      <button class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-xs transition-colors shadow-sm" (click)="openFieldForm(site.siteId || site.id)">
                         + Ajouter un terrain
                       </button>
                     </div>
                     <div class="space-y-2">
                       @for (field of fieldsBySiteId[site.siteId || site.id]; track field.fieldId || field.id) {
-                        <div class="p-3 border border-gray-100 bg-gray-50 hover:bg-gray-100 rounded-md flex justify-between items-center transition-colors">
-                          <div>
-                            <span class="font-bold text-gray-700">Terrain #{{ field.fieldId || field.id }}</span>
-                            <span class="bg-blue-100 text-blue-800 text-xs px-2 py-0.5 rounded ml-3 font-semibold shadow-sm">{{ field.sportType || field.type }}</span>
-                            <span class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded ml-2 shadow-sm">{{ field.fieldType || field.type }}</span>
+                        <div class="p-3 border border-gray-100 bg-gray-50 hover:bg-gray-100 rounded-md flex flex-col md:flex-row justify-between md:items-center gap-3 transition-colors">
+                          <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-2">
+                              <span class="font-bold text-gray-700">Terrain #{{ field.fieldId || field.id }}</span>
+                              <span class="bg-blue-100 text-blue-800 text-xs px-2 py-0.5 rounded font-semibold shadow-sm">
+                                {{ field.isIndoor ? 'Indoor' : 'Outdoor' }}
+                              </span>
+                              @if (field.maintenanceFromDate || field.maintenanceToDate) {
+                                <span class="bg-orange-100 text-orange-800 text-xs px-2 py-0.5 rounded font-semibold animate-pulse">
+                                  Maintenance: {{ field.maintenanceFromDate | date:'dd/MM' }} - {{ field.maintenanceToDate | date:'dd/MM' }}
+                                </span>
+                              }
+                            </div>
                           </div>
-                          <button class="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded text-xs transition-colors shadow-sm">
-                            Planifier une maintenance
-                          </button>
+                          <div class="flex gap-2">
+                            @if (field.maintenanceFromDate || field.maintenanceToDate) {
+                              <button class="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded text-xs transition-colors shadow-sm" (click)="cancelMaintenance(field)">
+                                Annuler maintenance
+                              </button>
+                            }
+                            <button class="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded text-xs transition-colors shadow-sm" (click)="openMaintenanceModal(field)">
+                              {{ (field.maintenanceFromDate || field.maintenanceToDate) ? 'Modifier maintenance' : 'Planifier maintenance' }}
+                            </button>
+                          </div>
                         </div>
                       }
                       @if (!fieldsBySiteId[site.siteId || site.id] || fieldsBySiteId[site.siteId || site.id].length === 0) {
@@ -251,3 +274,101 @@
 @if (showUserForm) {
   <app-user-form [sites]="sites" (close)="closeUserForm()" (signupCompleted)="onUserAdded($event)"></app-user-form>
 }
+
+@if (showMaintenanceModal) {
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-black/50 backdrop-blur-sm">
+    <div class="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-lg font-bold">Planifier une maintenance</h3>
+        <button (click)="closeMaintenanceModal()" class="text-gray-400 hover:text-gray-800 text-xl font-bold">✕</button>
+      </div>
+      <p class="text-sm text-gray-600 mb-4">Définissez les dates de maintenance pour le terrain #{{ selectedFieldForMaintenance?.fieldId || selectedFieldForMaintenance?.id }}.</p>
+
+      <form [formGroup]="maintenanceForm" (ngSubmit)="submitMaintenance()" class="flex flex-col gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Date de début</label>
+          <input type="date" formControlName="fromDate" class="w-full border border-gray-300 rounded-md p-2 focus:ring-blue-500 focus:border-blue-500">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Date de fin</label>
+          <input type="date" formControlName="toDate" class="w-full border border-gray-300 rounded-md p-2 focus:ring-blue-500 focus:border-blue-500">
+        </div>
+        <div class="flex justify-end gap-2 mt-4">
+          <button type="button" class="px-4 py-2 border rounded hover:bg-gray-50" (click)="closeMaintenanceModal()">Annuler</button>
+          <button type="submit" [disabled]="maintenanceForm.invalid || isSubmittingMaintenance" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 transition-colors">
+            {{ isSubmittingMaintenance ? 'Enregistrement...' : 'Enregistrer' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+}
+
+@if (showSiteForm) {
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-black/50 backdrop-blur-sm">
+    <div class="bg-white rounded-xl shadow-xl w-full max-w-lg p-8">
+      <div class="flex justify-between items-center mb-6">
+        <h3 class="text-2xl font-bold">Nouveau Site</h3>
+        <button (click)="closeSiteForm()" class="text-gray-400 hover:text-gray-800 text-xl font-bold">✕</button>
+      </div>
+
+      <form [formGroup]="siteForm" (ngSubmit)="submitSite()" class="flex flex-col gap-4">
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-1">Nom du site *</label>
+          <input type="text" formControlName="name" placeholder="Ex: Central Park" class="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+        </div>
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-1">Adresse *</label>
+          <input type="text" formControlName="address" placeholder="Ex: 5th Ave, New York" class="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-semibold text-gray-700 mb-1">Heure d'ouverture *</label>
+            <input type="time" formControlName="openingTime" class="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+          </div>
+          <div>
+            <label class="block text-sm font-semibold text-gray-700 mb-1">Heure de fermeture *</label>
+            <input type="time" formControlName="closingTime" class="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+          </div>
+        </div>
+
+        <div class="mt-6">
+          <button type="submit" [disabled]="siteForm.invalid || isSubmittingSite" class="w-full bg-blue-600 text-white font-bold py-3 rounded-full shadow-lg hover:bg-blue-700 disabled:opacity-50 transition-colors">
+            {{ isSubmittingSite ? 'CRÉATION...' : 'CRÉER LE SITE' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+}
+
+@if (showFieldForm) {
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-black/50 backdrop-blur-sm">
+    <div class="bg-white rounded-xl shadow-xl w-full max-w-md p-8">
+      <div class="flex justify-between items-center mb-6">
+        <h3 class="text-2xl font-bold">Nouveau Terrain</h3>
+        <button (click)="closeFieldForm()" class="text-gray-400 hover:text-gray-800 text-xl font-bold">✕</button>
+      </div>
+
+      <p class="text-gray-600 mb-6 text-center">Ajouter un nouveau terrain pour ce site.</p>
+
+      <form [formGroup]="fieldForm" (ngSubmit)="submitField()" class="flex flex-col gap-6">
+        <div class="flex justify-around items-center">
+          <label class="flex items-center gap-2 cursor-pointer group">
+            <input type="radio" [value]="true" formControlName="isIndoor" class="w-5 h-5 text-blue-600 border-gray-300 focus:ring-blue-500">
+            <span class="text-lg font-medium group-hover:text-blue-600 transition-colors">Indoor</span>
+          </label>
+          <label class="flex items-center gap-2 cursor-pointer group">
+            <input type="radio" [value]="false" formControlName="isIndoor" class="w-5 h-5 text-blue-600 border-gray-300 focus:ring-blue-500">
+            <span class="text-lg font-medium group-hover:text-blue-600 transition-colors">Outdoor</span>
+          </label>
+        </div>
+
+        <button type="submit" [disabled]="fieldForm.invalid || isSubmittingField" class="w-full bg-blue-600 text-white font-bold py-3 rounded-full shadow-lg hover:bg-blue-700 disabled:opacity-50 transition-colors mt-4">
+          {{ isSubmittingField ? 'CRÉATION...' : 'AJOUTER TERRAIN' }}
+        </button>
+      </form>
+    </div>
+  </div>
+}
+

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -227,7 +227,7 @@
           <label class="block text-sm font-medium text-gray-700 mb-1">Nouveau mot de passe</label>
           <input type="password" formControlName="newPassword" class="w-full border border-gray-300 rounded-md p-2 focus:ring-blue-500 focus:border-blue-500">
           @if (passwordForm.get('newPassword')?.touched && passwordForm.get('newPassword')?.invalid) {
-            <p class="text-xs text-red-500 mt-1">Le mot de passe doit faire au moins 8 caractères, inclure majuscule, minuscule, chiffre et un des caractères suivants : @!-+&$€</p>
+            <p class="text-xs text-red-500 mt-1">Le mot de passe doit faire au moins 8 caractères, inclure majuscule, minuscule, chiffre et un des caractères suivants : &#64;!-+&$€</p>
           }
         </div>
 

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.html
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.html
@@ -1,1 +1,253 @@
-<!--NOT YET IMPLEMENTED-->
+<div class="relative flex flex-col min-h-screen px-4 md:px-8">
+  <app-home-account-header></app-home-account-header>
+
+  <div class="flex flex-1 mid:flex-row relative">
+    <main class="flex-1 p-6 relative flex flex-col items-stretch z-10">
+      <div class="max-w-6xl mx-auto w-full bg-white/60 backdrop-blur-sm border border-gray-200 p-6 rounded-xl mt-6">
+        <h2 class="font-bold text-2xl mb-4">Panneau d'administration</h2>
+
+        @if (loading) {
+          <div class="text-sm text-gray-600 mb-4">Chargement...</div>
+        }
+
+        <div class="flex gap-4 border-b pb-2 mb-6">
+          <button (click)="activeTab = 'users'"
+                  [class.border-b-2]="activeTab === 'users'"
+                  [class.border-blue-600]="activeTab === 'users'"
+                  class="pb-2 font-medium hover:text-blue-600 transition-colors">
+            Utilisateurs
+          </button>
+          <button (click)="activeTab = 'sites'"
+                  [class.border-b-2]="activeTab === 'sites'"
+                  [class.border-blue-600]="activeTab === 'sites'"
+                  class="pb-2 font-medium hover:text-blue-600 transition-colors">
+            Sites
+          </button>
+        </div>
+
+        @if (activeTab === 'users') {
+          <div class="mb-4 flex flex-row-reverse">
+            <button class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded text-sm transition-colors shadow-sm" (click)="openUserForm()">+ Nouvel Utilisateur</button>
+          </div>
+
+          <!-- Filtres -->
+          <div class="mb-4 bg-gray-50 p-4 rounded-lg border border-gray-200 flex flex-col gap-2">
+            <h2 class="font-semibold text-gray-600 m-0">Filtres</h2>
+            <div class="flex flex-wrap gap-4 items-end">
+              <div>
+                <label class="block text-xs font-semibold text-gray-600 mb-1">Nom</label>
+                <input type="text" [(ngModel)]="userFilters.name" placeholder="Nom..." class="border border-gray-300 rounded p-1.5 text-sm w-32 focus:ring-blue-500">
+              </div>
+              <div>
+                <label class="block text-xs font-semibold text-gray-600 mb-1">Email</label>
+                <input type="text" [(ngModel)]="userFilters.email" placeholder="Email..." class="border border-gray-300 rounded p-1.5 text-sm w-40 focus:ring-blue-500">
+              </div>
+              <div>
+                <label class="block text-xs font-semibold text-gray-600 mb-1">Site</label>
+                <select [(ngModel)]="userFilters.siteId" class="border border-gray-300 rounded p-1.5 text-sm min-w-32 focus:ring-blue-500">
+                  <option value="">Tous</option>
+                  @for (site of sites; track site.siteId || site.id) {
+                    <option [value]="site.siteId || site.id">{{ site.name || site.siteName || site.siteId }}</option>
+                  }
+                </select>
+              </div>
+              <div>
+                <label class="block text-xs font-semibold text-gray-600 mb-1">Statut</label>
+                <select [(ngModel)]="userFilters.isActive" class="border border-gray-300 rounded p-1.5 text-sm min-w-24 focus:ring-blue-500">
+                  <option value="">Tous</option>
+                  <option value="true">Actif</option>
+                  <option value="false">Inactif</option>
+                </select>
+              </div>
+              <div class="flex items-center gap-2 mb-1.5">
+                <input type="checkbox" id="f-debt" [(ngModel)]="userFilters.hasDebt" class="rounded border-gray-300">
+                <label for="f-debt" class="text-sm font-semibold text-gray-700">Dette (non nul)</label>
+              </div>
+              <div class="flex items-center gap-2 mb-1.5">
+                <input type="checkbox" id="f-pen" [(ngModel)]="userFilters.hasPenalty" class="rounded border-gray-300">
+                <label for="f-pen" class="text-sm font-semibold text-gray-700">Pénalité (non nul)</label>
+              </div>
+            </div>
+          </div>
+
+          <div class="overflow-x-auto shadow-sm rounded-lg border border-gray-200">
+            <table class="min-w-full bg-white text-left text-sm whitespace-nowrap">
+              <thead class="bg-gray-100 text-gray-700">
+                <tr>
+                  <th class="px-4 py-3 font-semibold">Nom</th>
+                  <th class="px-4 py-3 font-semibold">Email</th>
+                  <th class="px-4 py-3 font-semibold">Sites</th>
+                  <th class="px-4 py-3 font-semibold text-center">Actif</th>
+                  <th class="px-4 py-3 font-semibold text-center">Dette</th>
+                  <th class="px-4 py-3 font-semibold text-center">Pénalité</th>
+                  <th class="px-4 py-3 font-semibold text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                @for (user of filteredUsers; track user.matricule || user.id) {
+                  <tr class="hover:bg-gray-50 transition-colors">
+                    <td class="px-4 py-3 font-medium text-gray-800">
+                      @if (user.roleId == 9) {
+                        <span class="text-red-600 font-bold mr-1">SA:</span>
+                      } @else if (user.roleId == 7) {
+                        <span class="text-red-600 font-bold mr-1">SITE:</span>
+                      }
+                      {{ user.firstName }} {{ user.lastName }}
+                    </td>
+                    <td class="px-4 py-3 text-gray-600">{{ user.email }}</td>
+                    <td class="px-4 py-3 text-gray-600">
+                      @if (user.sites && user.sites.length > 0) {
+                        <div class="flex flex-wrap gap-1">
+                          @for (s of user.sites; track $index) {
+                            <span class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded">{{ s.siteName || s.name || s.siteId }}</span>
+                          }
+                        </div>
+                      } @else {
+                        <span class="text-gray-400 text-xs italic">-</span>
+                      }
+                    </td>
+                    <td class="px-4 py-3 text-center">
+                      <span class="px-2 py-1 rounded-full text-xs font-semibold"
+                            [class.bg-green-100]="user.isActive" [class.text-green-800]="user.isActive"
+                            [class.bg-red-100]="!user.isActive" [class.text-red-800]="!user.isActive">
+                        {{ user.isActive ? 'Actif' : 'Inactif' }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-3 text-center">
+                      @if (user.account?.balance < 0) {
+                        <span class="text-red-600 font-bold bg-red-50 px-2 py-1 rounded">{{ user.account?.balance }} €</span>
+                      } @else {
+                        <span class="text-gray-400">-</span>
+                      }
+                    </td>
+                    <td class="px-4 py-3 text-center">
+                      @if (user.penalties?.length > 0) {
+                        <span class="text-red-600 font-bold bg-red-100 px-2 py-0.5 rounded-full text-xs">{{ user.penalties.length }}</span>
+                      } @else {
+                        <span class="text-gray-400">-</span>
+                      }
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                      <div class="flex gap-2 justify-end">
+                        <button class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded text-xs transition-colors shadow-sm" (click)="openPasswordModal(user)">
+                          Modifier Mot de Passe
+                        </button>
+                        <button class="text-white px-3 py-1.5 rounded text-xs transition-colors shadow-sm"
+                                [class.bg-orange-500]="user.isActive" [class.hover:bg-orange-600]="user.isActive"
+                                [class.bg-green-600]="!user.isActive" [class.hover:bg-green-700]="!user.isActive"
+                                (click)="toggleUserActiveStatus(user)">
+                          {{ user.isActive ? 'Désactiver' : 'Réactiver' }}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+
+        @if (activeTab === 'sites') {
+          <div class="mb-4 flex flex-row-reverse">
+            <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm transition-colors">Ajouter un site</button>
+          </div>
+          <div class="space-y-4">
+            @for (site of sites; track site.siteId || site.id) {
+              <div class="p-4 bg-white rounded-md shadow flex flex-col gap-2">
+                <div class="flex justify-between items-center cursor-pointer" (click)="toggleSite(site.siteId || site.id)">
+                  <span class="font-bold text-lg select-none flex items-baseline gap-3 flex-wrap">
+                    {{ site.name || site.siteName }}
+                    @if (site.address || site.city) {
+                      <span class="text-sm font-normal text-gray-600 whitespace-nowrap">📍 {{ site.address || '' }} {{ site.city || '' }}</span>
+                    }
+                    <span class="text-sm font-normal text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">
+                      {{ fieldsBySiteId[site.siteId || site.id]?.length || 0 }} terrains
+                    </span>
+                  </span>
+                  <div class="flex gap-2">
+                    <button class="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded text-sm transition-colors" (click)="$event.stopPropagation()">
+                      Désactiver
+                    </button>
+                    <button class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded text-sm transition-colors">
+                      {{ expandedSiteId === (site.siteId || site.id) ? '▲' : '▼' }}
+                    </button>
+                  </div>
+                </div>
+
+                @if (expandedSiteId === (site.siteId || site.id)) {
+                  <div class="mt-4 border-t pt-4">
+                    <div class="flex justify-between items-center mb-3">
+                      <h4 class="font-semibold text-md text-gray-700">Terrains pour {{ site.name || site.siteName }}</h4>
+                      <button class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-xs transition-colors">
+                        + Ajouter un terrain
+                      </button>
+                    </div>
+                    <div class="space-y-2">
+                      @for (field of fieldsBySiteId[site.siteId || site.id]; track field.fieldId || field.id) {
+                        <div class="p-3 border border-gray-100 bg-gray-50 hover:bg-gray-100 rounded-md flex justify-between items-center transition-colors">
+                          <div>
+                            <span class="font-bold text-gray-700">Terrain #{{ field.fieldId || field.id }}</span>
+                            <span class="bg-blue-100 text-blue-800 text-xs px-2 py-0.5 rounded ml-3 font-semibold shadow-sm">{{ field.sportType || field.type }}</span>
+                            <span class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded ml-2 shadow-sm">{{ field.fieldType || field.type }}</span>
+                          </div>
+                          <button class="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded text-xs transition-colors shadow-sm">
+                            Désactiver
+                          </button>
+                        </div>
+                      }
+                      @if (!fieldsBySiteId[site.siteId || site.id] || fieldsBySiteId[site.siteId || site.id].length === 0) {
+                        <div class="text-sm italic text-gray-500 text-center py-2">Aucun terrain configuré pour ce site.</div>
+                      }
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        }
+
+      </div>
+    </main>
+    <app-nav-menu></app-nav-menu>
+  </div>
+</div>
+
+@if (showPasswordModal) {
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-black/50 backdrop-blur-sm">
+    <div class="bg-white rounded-xl shadow-xl w-full max-w-md overflow-hidden flex flex-col p-6">
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-lg font-bold">Nouveau mot de passe</h3>
+        <button (click)="closePasswordModal()" class="text-gray-400 hover:text-gray-800 text-xl font-bold">✕</button>
+      </div>
+
+      <p class="text-sm text-gray-600 mb-4">Changer le mot de passe pour <strong>{{ selectedUserEmailForPassword }}</strong>.</p>
+
+      <form [formGroup]="passwordForm" (ngSubmit)="submitPasswordChange()" class="flex flex-col gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Nouveau mot de passe</label>
+          <input type="password" formControlName="newPassword" class="w-full border border-gray-300 rounded-md p-2 focus:ring-blue-500 focus:border-blue-500">
+          @if (passwordForm.get('newPassword')?.touched && passwordForm.get('newPassword')?.invalid) {
+            <p class="text-xs text-red-500 mt-1">Le mot de passe doit faire au moins 8 caractères, inclure majuscule, minuscule, chiffre et un des caractères suivants : @!-+&$€</p>
+          }
+        </div>
+
+        @if (passwordUpdateMessage) {
+          <div class="text-sm p-3 rounded" [class.bg-green-100]="!passwordUpdateError" [class.text-green-800]="!passwordUpdateError" [class.bg-red-100]="passwordUpdateError" [class.text-red-800]="passwordUpdateError">
+            {{ passwordUpdateMessage }}
+          </div>
+        }
+
+        <div class="flex justify-end gap-2 mt-2">
+          <button type="button" class="px-4 py-2 border rounded hover:bg-gray-50" (click)="closePasswordModal()">Annuler</button>
+          <button type="submit" [disabled]="passwordForm.invalid || isSubmittingPassword" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 transition-colors">
+            {{ isSubmittingPassword ? (passwordUpdateMessage && !passwordUpdateError ? 'Succès!' : 'Patientez...') : 'Enregistrer' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+}
+
+@if (showUserForm) {
+  <app-user-form [sites]="sites" (close)="closeUserForm()" (signupCompleted)="onUserAdded($event)"></app-user-form>
+}

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -168,11 +168,11 @@ export class AdminComponent implements OnInit {
     user.isActive = !user.isActive;
 
     this.userService.updateUserInBackend(matricule, { isActive: user.isActive }).subscribe({
-      next: (updated) => {
+      next: () => {
         // Success
         this.cd.detectChanges();
       },
-      error: (err) => {
+      error: () => {
         // Revert on error
         user.isActive = previousStatus;
         alert("Erreur lors de la mise à jour du statut de l'utilisateur.");
@@ -210,7 +210,7 @@ export class AdminComponent implements OnInit {
     this.cd.detectChanges();
   }
 
-  onUserAdded(newUser: any) {
+  onUserAdded(_newUser?: any) {
     this.closeUserForm();
     window.location.reload();
   }
@@ -258,7 +258,7 @@ export class AdminComponent implements OnInit {
         this.cd.detectChanges();
         setTimeout(() => this.closePasswordModal(), 1500);
       },
-      error: (err) => {
+      error: () => {
         this.passwordUpdateMessage = "Erreur lors de la mise à jour du mot de passe.";
         this.passwordUpdateError = true;
         this.isSubmittingPassword = false;

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -47,11 +47,18 @@ export class AdminComponent implements OnInit {
 
   showUserForm = false;
 
-  userFilters = {
-    name: '' as string,
-    email: '' as string,
-    siteId: '' as string,
-    isActive: '' as string,
+  userFilters: {
+    name: string;
+    email: string;
+    siteId: string;
+    isActive: string;
+    hasDebt: boolean;
+    hasPenalty: boolean;
+  } = {
+    name: '',
+    email: '',
+    siteId: '',
+    isActive: '',
     hasDebt: false,
     hasPenalty: false
   };

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -9,9 +9,10 @@ import { FieldService } from '../../../../services/field.service';
 import { catchError, of, Observable } from 'rxjs';
 import { FormsModule, ReactiveFormsModule, FormGroup, FormControl, Validators, AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { UserFormComponent } from '../../user-form/user-form';
+import { SiteDto, FieldDto } from '../../../../api';
 
 export function passwordStrengthValidator(): ValidatorFn {
-  const pattern = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[@!\-\+&\$€])[A-Za-z0-9@!\-\+&\$€]{8,}$/;
+  const pattern = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[@!\-+&$€])[A-Za-z0-9@!\-+&$€]{8,}$/;
   return (control: AbstractControl): ValidationErrors | null => {
     const v = control.value as string | null | undefined;
     if (!v) return { weakPassword: true };
@@ -33,6 +34,36 @@ export class AdminComponent implements OnInit {
   sites: any[] = [];
   fieldsBySiteId: { [key: number]: any[] } = {};
   expandedSiteId: number | null = null;
+
+  // Site Toggle
+  isTogglingSite = false;
+
+  // Field Maintenance Modal
+  showMaintenanceModal = false;
+  selectedFieldForMaintenance: any = null;
+  maintenanceForm = new FormGroup({
+    fromDate: new FormControl('', [Validators.required]),
+    toDate: new FormControl('', [Validators.required])
+  });
+  isSubmittingMaintenance = false;
+
+  // Create Site Modal
+  showSiteForm = false;
+  siteForm = new FormGroup({
+    name: new FormControl('', [Validators.required]),
+    address: new FormControl('', [Validators.required]),
+    openingTime: new FormControl('08:00:00', [Validators.required]),
+    closingTime: new FormControl('22:00:00', [Validators.required])
+  });
+  isSubmittingSite = false;
+
+  // Create Field Modal
+  showFieldForm = false;
+  selectedSiteIdForNewField: number | null = null;
+  fieldForm = new FormGroup({
+    isIndoor: new FormControl(true, [Validators.required])
+  });
+  isSubmittingField = false;
 
   // Password reset Modal state
   showPasswordModal = false;
@@ -192,6 +223,189 @@ export class AdminComponent implements OnInit {
         // Revert on error
         user.isActive = previousStatus;
         alert("Erreur lors de la mise à jour du statut de l'utilisateur.");
+        this.cd.detectChanges();
+      }
+    });
+  }
+
+  toggleSiteActiveStatus(site: any) {
+    const sid = site.siteId || site.id;
+    if (!sid) return;
+
+    this.isTogglingSite = true;
+    const previousStatus = site.isActive;
+    site.isActive = !site.isActive;
+
+    const siteUpdate: SiteDto = {
+      isActive: site.isActive
+    };
+
+    this.siteService.updateSite(sid, siteUpdate).subscribe({
+      next: () => {
+        this.isTogglingSite = false;
+        this.cd.detectChanges();
+      },
+      error: () => {
+        site.isActive = previousStatus;
+        this.isTogglingSite = false;
+        alert("Erreur lors de la mise à jour du statut du site.");
+        this.cd.detectChanges();
+      }
+    });
+  }
+
+  openMaintenanceModal(field: any) {
+    this.selectedFieldForMaintenance = field;
+    this.showMaintenanceModal = true;
+    this.maintenanceForm.reset({
+      fromDate: field.maintenanceFromDate || '',
+      toDate: field.maintenanceToDate || ''
+    });
+    this.cd.detectChanges();
+  }
+
+  closeMaintenanceModal() {
+    this.showMaintenanceModal = false;
+    this.selectedFieldForMaintenance = null;
+    this.cd.detectChanges();
+  }
+
+  submitMaintenance() {
+    if (this.maintenanceForm.invalid || !this.selectedFieldForMaintenance) return;
+
+    this.isSubmittingMaintenance = true;
+    const fid = this.selectedFieldForMaintenance.fieldId || this.selectedFieldForMaintenance.id;
+    const fieldUpdate: any = {
+      maintenanceFromDate: this.maintenanceForm.value.fromDate || null,
+      maintenanceToDate: this.maintenanceForm.value.toDate || null
+    };
+
+    this.fieldService.updateField(fid, fieldUpdate).subscribe({
+      next: () => {
+        this.selectedFieldForMaintenance.maintenanceFromDate = fieldUpdate.maintenanceFromDate;
+        this.selectedFieldForMaintenance.maintenanceToDate = fieldUpdate.maintenanceToDate;
+        this.isSubmittingMaintenance = false;
+        this.closeMaintenanceModal();
+        this.cd.detectChanges();
+      },
+      error: () => {
+        this.isSubmittingMaintenance = false;
+        alert("Erreur lors de la mise à jour des dates de maintenance.");
+        this.cd.detectChanges();
+      }
+    });
+  }
+
+  cancelMaintenance(field: any) {
+    const fid = field.fieldId || field.id;
+
+    // Calculate yesterday's date in YYYY-MM-DD format as a workaround
+    // since the backend might ignore null values in PATCH requests.
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+    const fieldUpdate: any = {
+      maintenanceFromDate: yesterdayStr,
+      maintenanceToDate: yesterdayStr
+    };
+
+    this.fieldService.updateField(fid, fieldUpdate).subscribe({
+      next: () => {
+        field.maintenanceFromDate = yesterdayStr;
+        field.maintenanceToDate = yesterdayStr;
+        this.cd.detectChanges();
+      },
+      error: () => {
+        alert("Erreur lors de l'annulation de la maintenance.");
+        this.cd.detectChanges();
+      }
+    });
+  }
+
+  openSiteForm() {
+    this.showSiteForm = true;
+    this.siteForm.reset({
+      openingTime: '08:00:00',
+      closingTime: '22:00:00'
+    });
+    this.cd.detectChanges();
+  }
+
+  closeSiteForm() {
+    this.showSiteForm = false;
+    this.cd.detectChanges();
+  }
+
+  submitSite() {
+    if (this.siteForm.invalid) return;
+
+    this.isSubmittingSite = true;
+
+    // We send time strings "HH:mm:ss" as the backend Jackson expects strings or arrays for LocalTime
+    const opening = this.siteForm.value.openingTime || '08:00:00';
+    const closing = this.siteForm.value.closingTime || '22:00:00';
+
+    // Ensure they have the seconds part if only HH:mm is provided
+    const formattedOpening = opening.split(':').length === 2 ? `${opening}:00` : opening;
+    const formattedClosing = closing.split(':').length === 2 ? `${closing}:00` : closing;
+
+    const siteDto: SiteDto = {
+      name: this.siteForm.value.name!,
+      address: this.siteForm.value.address!,
+      openingTime: formattedOpening as any, // Cast to any because SiteDto interface expects LocalTime object
+      closingTime: formattedClosing as any,
+      isActive: true
+    };
+
+    this.siteService.createSite(siteDto).subscribe({
+      next: () => {
+        this.isSubmittingSite = false;
+        this.closeSiteForm();
+        this.loadData(); // Reload sites
+      },
+      error: () => {
+        this.isSubmittingSite = false;
+        alert("Erreur lors de la création du site.");
+        this.cd.detectChanges();
+      }
+    });
+  }
+
+  openFieldForm(siteId: number) {
+    this.selectedSiteIdForNewField = siteId;
+    this.showFieldForm = true;
+    this.fieldForm.reset({
+      isIndoor: true
+    });
+    this.cd.detectChanges();
+  }
+
+  closeFieldForm() {
+    this.showFieldForm = false;
+    this.selectedSiteIdForNewField = null;
+    this.cd.detectChanges();
+  }
+
+  submitField() {
+    if (this.fieldForm.invalid || !this.selectedSiteIdForNewField) return;
+
+    this.isSubmittingField = true;
+    const fieldDto: FieldDto = {
+      siteId: this.selectedSiteIdForNewField,
+      isIndoor: this.fieldForm.value.isIndoor!,
+      isActive: true
+    };
+
+    this.fieldService.createField(fieldDto).subscribe({
+      next: () => {
+        this.isSubmittingField = false;
+        this.closeFieldForm();
+        this.loadAllFields(); // Reload fields
+      },
+      error: () => {
+        this.isSubmittingField = false;
+        alert("Erreur lors de la création du terrain.");
         this.cd.detectChanges();
       }
     });

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -6,7 +6,7 @@ import { HomeAccountHeader } from '../../header/header';
 import { UserService } from '../../../../services/user.service';
 import { SiteService } from '../../../../services/site.service';
 import { FieldService } from '../../../../services/field.service';
-import { catchError, of } from 'rxjs';
+import { catchError, of, Observable } from 'rxjs';
 import { FormsModule, ReactiveFormsModule, FormGroup, FormControl, Validators, AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { UserFormComponent } from '../../user-form/user-form';
 
@@ -77,8 +77,53 @@ export class AdminComponent implements OnInit {
   loadData() {
     this.loading = true;
 
-    // Load Users
-    this.userService.getAllUsers().pipe(
+    // Load current user first to determine permissions
+    this.userService.getCurrentUser().pipe(
+      catchError((err) => {
+        console.error('Failed to load current user', err);
+        return of(null);
+      })
+    ).subscribe((profile) => {
+      if (!profile) {
+        this.loading = false;
+        this.cd.detectChanges();
+        return;
+      }
+
+      const roleId = Number(profile?.roleId ?? -1);
+      const isAllSites = [2, 9].includes(roleId) || (profile?.sites && profile.sites.some((s: any) => s.isVip));
+
+      if (isAllSites) {
+        // Load all sites for super admins
+        this.siteService.getAllSites().pipe(
+          catchError(() => of([]))
+        ).subscribe((sites) => {
+          this.sites = sites || [];
+          this.loadAllFields();
+        });
+
+        // Load all users
+        this.fetchUsers(this.userService.getAllUsers());
+      } else {
+        // Use assigned sites
+        this.sites = profile?.sites || [];
+        this.loadAllFields();
+
+        // Load specific users if Site Admin
+        if (roleId === 7 && this.sites.length > 0) {
+          const primarySite = this.sites.find((s: any) => s.isPrimary) || this.sites[0];
+          const siteId = primarySite.siteId || primarySite.id;
+          this.fetchUsers(this.userService.getUsersForSite(siteId));
+        } else {
+          this.users = [];
+          this.cd.detectChanges();
+        }
+      }
+    });
+  }
+
+  private fetchUsers(source: Observable<any[]>) {
+    source.pipe(
       catchError((err) => {
         console.error('Failed to load users', err);
         return of([]);
@@ -102,35 +147,6 @@ export class AdminComponent implements OnInit {
       });
 
       this.cd.detectChanges();
-    });
-
-    // Load Sites & Fields based on user role
-    this.userService.getCurrentUser().pipe(
-      catchError((err) => {
-        console.error('Failed to load current user', err);
-        return of(null);
-      })
-    ).subscribe((profile) => {
-      if (!profile) {
-        this.loading = false;
-        this.cd.detectChanges();
-        return;
-      }
-
-      const roleId = profile?.roleId ?? -1;
-      const isAllSites = [2, 9].includes(Number(roleId)) || (profile?.sites && profile.sites.some((s: any) => s.isVip));
-
-      if (isAllSites) {
-        this.siteService.getAllSites().pipe(
-          catchError(() => of([]))
-        ).subscribe((sites) => {
-          this.sites = sites || [];
-          this.loadAllFields();
-        });
-      } else {
-        this.sites = profile?.sites || [];
-        this.loadAllFields(); // Load fields for their assigned sites
-      }
     });
   }
 

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -1,1 +1,262 @@
-//NOT YET IMPLEMENTED
+import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { NavMenu } from '../../nav-menu/nav-menu';
+import { HomeAccountHeader } from '../../header/header';
+import { UserService } from '../../../../services/user.service';
+import { SiteService } from '../../../../services/site.service';
+import { FieldService } from '../../../../services/field.service';
+import { catchError, of } from 'rxjs';
+import { FormsModule, ReactiveFormsModule, FormGroup, FormControl, Validators, AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { UserFormComponent } from '../../user-form/user-form';
+
+export function passwordStrengthValidator(): ValidatorFn {
+  const pattern = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[@!\-\+&\$€])[A-Za-z0-9@!\-\+&\$€]{8,}$/;
+  return (control: AbstractControl): ValidationErrors | null => {
+    const v = control.value as string | null | undefined;
+    if (!v) return { weakPassword: true };
+    return pattern.test(v) ? null : { weakPassword: true };
+  };
+}
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  imports: [CommonModule, RouterModule, NavMenu, HomeAccountHeader, FormsModule, ReactiveFormsModule, UserFormComponent],
+  templateUrl: './admin.html'
+})
+export class AdminComponent implements OnInit {
+  activeTab: 'users' | 'sites' = 'users';
+  loading = false;
+
+  users: any[] = [];
+  sites: any[] = [];
+  fieldsBySiteId: { [key: number]: any[] } = {};
+  expandedSiteId: number | null = null;
+
+  // Password reset Modal state
+  showPasswordModal = false;
+  selectedUserIdForPassword: string | null = null;
+  selectedUserEmailForPassword: string | null = null;
+  passwordForm = new FormGroup({
+    newPassword: new FormControl('', [Validators.required, Validators.minLength(8), passwordStrengthValidator()]),
+  });
+  passwordUpdateMessage: string | null = null;
+  passwordUpdateError = false;
+  isSubmittingPassword = false;
+
+  showUserForm = false;
+
+  userFilters = {
+    name: '',
+    email: '',
+    siteId: '',
+    isActive: '',
+    hasDebt: false,
+    hasPenalty: false
+  };
+
+  constructor(
+    private userService: UserService,
+    private siteService: SiteService,
+    private fieldService: FieldService,
+    private cd: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  loadData() {
+    this.loading = true;
+
+    // Load Users
+    this.userService.getAllUsers().pipe(
+      catchError((err) => {
+        console.error('Failed to load users', err);
+        return of([]);
+      })
+    ).subscribe((users) => {
+      this.users = users || [];
+
+      // Pin Admins to top (SA = 9, SITE = 7)
+      this.users.sort((a, b) => {
+        const roleA = Number(a.roleId);
+        const roleB = Number(b.roleId);
+        const aIsAdmin = roleA === 9 || roleA === 7;
+        const bIsAdmin = roleB === 9 || roleB === 7;
+
+        if (aIsAdmin && !bIsAdmin) return -1;
+        if (!aIsAdmin && bIsAdmin) return 1;
+        if (aIsAdmin && bIsAdmin && roleA !== roleB) {
+          return roleA === 9 ? -1 : 1; // SA before SITE
+        }
+        return 0;
+      });
+
+      this.cd.detectChanges();
+    });
+
+    // Load Sites & Fields based on user role
+    this.userService.getCurrentUser().pipe(
+      catchError((err) => {
+        console.error('Failed to load current user', err);
+        return of(null);
+      })
+    ).subscribe((profile) => {
+      if (!profile) {
+        this.loading = false;
+        this.cd.detectChanges();
+        return;
+      }
+
+      const roleId = profile?.roleId ?? -1;
+      const isAllSites = [2, 9].includes(Number(roleId)) || (profile?.sites && profile.sites.some((s: any) => s.isVip));
+
+      if (isAllSites) {
+        this.siteService.getAllSites().pipe(
+          catchError(() => of([]))
+        ).subscribe((sites) => {
+          this.sites = sites || [];
+          this.loadAllFields();
+        });
+      } else {
+        this.sites = profile?.sites || [];
+        this.loadAllFields(); // Load fields for their assigned sites
+      }
+    });
+  }
+
+  loadAllFields() {
+    this.fieldService.fetchAllFields().pipe(
+      catchError(() => of([]))
+    ).subscribe((fields) => {
+      this.fieldsBySiteId = {};
+      (fields || []).forEach((f: any) => {
+        const sid = f.siteId ?? f.site?.siteId;
+        if (sid) {
+          if (!this.fieldsBySiteId[sid]) this.fieldsBySiteId[sid] = [];
+          this.fieldsBySiteId[sid].push(f);
+        }
+      });
+      this.loading = false;
+      this.cd.detectChanges();
+    });
+  }
+
+  toggleSite(siteId: number) {
+    if (this.expandedSiteId === siteId) {
+      this.expandedSiteId = null;
+    } else {
+      this.expandedSiteId = siteId;
+    }
+  }
+
+  toggleUserActiveStatus(user: any) {
+    const matricule = user.matricule || user.id;
+    if (!matricule) return;
+
+    // Optimistic UI update
+    const previousStatus = user.isActive;
+    user.isActive = !user.isActive;
+
+    this.userService.updateUserInBackend(matricule, { isActive: user.isActive }).subscribe({
+      next: (updated) => {
+        // Success
+        this.cd.detectChanges();
+      },
+      error: (err) => {
+        // Revert on error
+        user.isActive = previousStatus;
+        alert("Erreur lors de la mise à jour du statut de l'utilisateur.");
+        this.cd.detectChanges();
+      }
+    });
+  }
+
+  openPasswordModal(user: any) {
+    this.selectedUserIdForPassword = user.matricule || user.id;
+    this.selectedUserEmailForPassword = user.email;
+    this.showPasswordModal = true;
+    this.passwordForm.reset();
+    this.passwordUpdateMessage = null;
+    this.passwordUpdateError = false;
+    this.isSubmittingPassword = false;
+    this.cd.detectChanges();
+  }
+
+  closePasswordModal() {
+    this.showPasswordModal = false;
+    this.selectedUserIdForPassword = null;
+    this.selectedUserEmailForPassword = null;
+    this.isSubmittingPassword = false;
+    this.cd.detectChanges();
+  }
+
+  openUserForm() {
+    this.showUserForm = true;
+    this.cd.detectChanges();
+  }
+
+  closeUserForm() {
+    this.showUserForm = false;
+    this.cd.detectChanges();
+  }
+
+  onUserAdded(newUser: any) {
+    this.closeUserForm();
+    window.location.reload();
+  }
+
+  get filteredUsers() {
+    return this.users.filter(u => {
+      if (this.userFilters.name) {
+        const fullName = `${u.firstName || ''} ${u.lastName || ''}`.toLowerCase();
+        if (!fullName.includes(this.userFilters.name.toLowerCase())) return false;
+      }
+      if (this.userFilters.email) {
+        const mail = (u.email || '').toLowerCase();
+        if (!mail.includes(this.userFilters.email.toLowerCase())) return false;
+      }
+      if (this.userFilters.siteId) {
+        if (!u.sites || !u.sites.some((s: any) => String(s.siteId || s.id) === String(this.userFilters.siteId))) return false;
+      }
+      if (this.userFilters.isActive !== '') {
+        const isAct = this.userFilters.isActive === 'true';
+        if (u.isActive !== isAct) return false;
+      }
+      if (this.userFilters.hasDebt) {
+        if (!u.account || typeof u.account.balance !== 'number' || u.account.balance >= 0) return false;
+      }
+      if (this.userFilters.hasPenalty) {
+        if (!u.penalties || u.penalties.length === 0) return false;
+      }
+      return true;
+    });
+  }
+
+  submitPasswordChange() {
+    if (this.passwordForm.invalid || !this.selectedUserIdForPassword) return;
+
+    this.isSubmittingPassword = true;
+    this.passwordUpdateMessage = null;
+    this.passwordUpdateError = false;
+
+    const newPassword = this.passwordForm.value.newPassword;
+    this.userService.updateUserInBackend(this.selectedUserIdForPassword, { password: newPassword }).subscribe({
+      next: () => {
+        this.passwordUpdateMessage = "Le mot de passe a été mis à jour avec succès.";
+        this.passwordUpdateError = false;
+        // Keep isSubmittingPassword true to keep the button disabled during the timeout
+        this.cd.detectChanges();
+        setTimeout(() => this.closePasswordModal(), 1500);
+      },
+      error: (err) => {
+        this.passwordUpdateMessage = "Erreur lors de la mise à jour du mot de passe.";
+        this.passwordUpdateError = true;
+        this.isSubmittingPassword = false;
+        this.cd.detectChanges();
+      }
+    });
+  }
+}

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -300,21 +300,18 @@ export class AdminComponent implements OnInit {
   cancelMaintenance(field: any) {
     const fid = field.fieldId || field.id;
 
-    // Calculate yesterday's date in YYYY-MM-DD format as a workaround
-    // since the backend might ignore null values in PATCH requests.
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split('T')[0];
+    // Use 1970-01-01 as a magic date to signal the backend to set maintenance dates to null
+    const resetDate = "1970-01-01";
 
     const fieldUpdate: any = {
-      maintenanceFromDate: yesterdayStr,
-      maintenanceToDate: yesterdayStr
+      maintenanceFromDate: resetDate,
+      maintenanceToDate: resetDate
     };
 
     this.fieldService.updateField(fid, fieldUpdate).subscribe({
       next: () => {
-        field.maintenanceFromDate = yesterdayStr;
-        field.maintenanceToDate = yesterdayStr;
+        field.maintenanceFromDate = null;
+        field.maintenanceToDate = null;
         this.cd.detectChanges();
       },
       error: () => {

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -48,10 +48,10 @@ export class AdminComponent implements OnInit {
   showUserForm = false;
 
   userFilters = {
-    name: '',
-    email: '',
-    siteId: '',
-    isActive: '',
+    name: '' as string,
+    email: '' as string,
+    siteId: '' as string,
+    isActive: '' as string,
     hasDebt: false,
     hasPenalty: false
   };

--- a/frontend/src/app/layout/content/pages/admin-panel/admin.ts
+++ b/frontend/src/app/layout/content/pages/admin-panel/admin.ts
@@ -56,6 +56,7 @@ export class AdminComponent implements OnInit {
     closingTime: new FormControl('22:00:00', [Validators.required])
   });
   isSubmittingSite = false;
+  siteFormError: string | null = null;
 
   // Create Field Modal
   showFieldForm = false;
@@ -325,6 +326,7 @@ export class AdminComponent implements OnInit {
 
   openSiteForm() {
     this.showSiteForm = true;
+    this.siteFormError = null;
     this.siteForm.reset({
       openingTime: '08:00:00',
       closingTime: '22:00:00'
@@ -341,6 +343,7 @@ export class AdminComponent implements OnInit {
     if (this.siteForm.invalid) return;
 
     this.isSubmittingSite = true;
+    this.siteFormError = null;
 
     // We send time strings "HH:mm:ss" as the backend Jackson expects strings or arrays for LocalTime
     const opening = this.siteForm.value.openingTime || '08:00:00';
@@ -364,9 +367,9 @@ export class AdminComponent implements OnInit {
         this.closeSiteForm();
         this.loadData(); // Reload sites
       },
-      error: () => {
+      error: (err) => {
         this.isSubmittingSite = false;
-        alert("Erreur lors de la création du site.");
+        this.siteFormError = err.error?.message || "Erreur lors de la création du site.";
         this.cd.detectChanges();
       }
     });

--- a/frontend/src/app/layout/content/user-form/user-form.html
+++ b/frontend/src/app/layout/content/user-form/user-form.html
@@ -112,14 +112,14 @@
 				  <div class="flex flex-col gap-1 mt-4">
 					<label for="siteId" class="text-sm font-semibold text-gray-700">Site *</label>
 																	@if (signupForm.get('siteId')?.disabled && prefillSiteName) {
-																	  <!-- When the site is locked (invite-mode with a prefilling site), show a readonly display of the site name -->
-																	  <input type="text" readonly class="border border-gray-300 rounded-lg p-2 bg-gray-50" [value]="prefillSiteName" />
+																	  <!-- When the site is locked (invite-mode or role-7 admin), show a readonly display of the site name -->
+																	  <input type="text" readonly class="border border-gray-300 rounded-lg p-2 bg-gray-50 focus:outline-none" [value]="prefillSiteName" />
 																	}
 																	@if (!(signupForm.get('siteId')?.disabled && prefillSiteName)) {
 																	  <select id="siteId" formControlName="siteId" class="border border-gray-300 rounded-lg p-2 focus:ring-2 focus:ring-orange-500 focus:outline-none">
 																		<option [ngValue]="null" disabled>Choisissez un site</option>
 																		@for (s of sites; track s.siteId) {
-																		  <option [ngValue]="s.siteId">{{s.name}} — {{s.address}}</option>
+																		  <option [ngValue]="s.siteId">{{ s.name || $any(s).siteName }} @if (s.address) { — {{s.address}} }</option>
 																		}
 																	  </select>
 																	}

--- a/frontend/src/app/layout/content/user-form/user-form.ts
+++ b/frontend/src/app/layout/content/user-form/user-form.ts
@@ -135,12 +135,21 @@ export class UserFormComponent implements AfterViewInit, OnDestroy {
 	  this.signupForm.get('siteId')?.markAsTouched();
 	}
 
+				// If only one site is available (e.g. for Site Admin role 7), auto-select and lock it
+				if (this.sites && this.sites.length === 1) {
+				  const singleSite = this.sites[0];
+				  const sid = singleSite.siteId;
+				  if (sid !== undefined && sid !== null) {
+					this.signupForm.get('siteId')?.setValue(String(sid));
+					this.signupForm.get('siteId')?.disable({ onlySelf: true });
+					// Ensure prefillSiteName is set for the readonly display in template
+					if (!this.prefillSiteName) {
+					  this.prefillSiteName = (singleSite as any).name || (singleSite as any).siteName;
+					}
+				  }
+				}
+
 				// If inviteMode is set, preselect defaults and make the email and site fields non-editable
-				// according to the following rules (match-form behaviour):
-				// - If a prefilled site id was provided by the parent (match-form), use it and disable the site control.
-				// - Otherwise, if only one site is available for the user, preselect that site and disable the control.
-				// - If multiple sites are available and no prefill was provided, leave the site control enabled so the
-				//   invite can choose the appropriate site.
 				if (this.inviteMode) {
 
 				  // prefill email already set above; lock it
@@ -151,12 +160,14 @@ export class UserFormComponent implements AfterViewInit, OnDestroy {
 					this.signupForm.get('siteId')?.setValue(String(this.prefillSiteId));
 					this.signupForm.get('siteId')?.disable({ onlySelf: true });
 				  } else if (this.sites && this.sites.length === 1) {
-					// only one site available for this user -> preselect and lock it (match-form behaviour)
+					// already handled by general logic above, but kept for clarity in inviteMode
 					this.signupForm.get('siteId')?.setValue(String(this.sites[0].siteId));
 					this.signupForm.get('siteId')?.disable({ onlySelf: true });
 				  } else {
-					// multiple sites available and no explicit prefill -> allow choosing
-					this.signupForm.get('siteId')?.enable();
+					// multiple sites available and no explicit prefill -> allow choosing if not already disabled
+					if (this.sites && this.sites.length > 1 && (!this.prefillSiteId)) {
+						this.signupForm.get('siteId')?.enable();
+					}
 				  }
 				}
   }

--- a/frontend/src/app/services/field.service.ts
+++ b/frontend/src/app/services/field.service.ts
@@ -1,14 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { FieldControllerService } from '../api/api/fieldController.service';
+import { FieldControllerService, FieldDto } from '../api';
 import { AuthService } from './auth.service';
-import {FieldDto} from '../api';
 
 @Injectable({ providedIn: 'root' })
 export class FieldService {
 
-  constructor(private fieldService: FieldControllerService, private authService: AuthService) {
+  constructor(private fieldController: FieldControllerService, private authService: AuthService) {
   }
 
   // Public helper to set Authorization header on generated API services when needed
@@ -27,12 +26,12 @@ export class FieldService {
   // NOTE: use the "active" endpoint so callers get only active fields by default
   public fetchFieldsBySite(siteId: number): Observable<any[]> {
     try {
-      this.setAuthHeader(this.fieldService);
+      this.setAuthHeader(this.fieldController);
     } catch (e) {
       // ignore
     }
     // Use getActiveFieldsBySite to avoid returning inactive fields to UI flows
-    return this.fieldService.getActiveFieldsBySite(siteId).pipe(
+    return this.fieldController.getActiveFieldsBySite(siteId).pipe(
       catchError((err) => {
         console.error('SessionService.fetchFieldsBySite (active) error', err);
         return of([]);
@@ -43,16 +42,26 @@ export class FieldService {
   // Get ALL fields
   public fetchAllFields(): Observable<FieldDto[]> {
     try {
-      this.setAuthHeader(this.fieldService);
+      this.setAuthHeader(this.fieldController);
     } catch (e) {
       // ignore
     }
 
-    return this.fieldService.getAllFields().pipe(
+    return this.fieldController.getAllFields().pipe(
       catchError((err) => {
         console.error('SessionService.getAllFields error', err);
         return of([]);
       })
     );
+  }
+
+  // Create a field
+  public createField(fieldDto: FieldDto): Observable<FieldDto> {
+    return this.fieldController.newField(fieldDto as any);
+  }
+
+  // Update a field
+  public updateField(id: number, fieldDto: FieldDto): Observable<FieldDto> {
+    return this.fieldController.updateField(id, fieldDto as any);
   }
 }

--- a/frontend/src/app/services/site.service.ts
+++ b/frontend/src/app/services/site.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { SiteControllerService } from '../api';
+import { SiteControllerService, SiteDto } from '../api';
 import { Observable } from 'rxjs';
 import { Site } from '../api';
 import { AuthService } from './auth.service';
@@ -28,5 +28,13 @@ export class SiteService {
   getAllSites(active?: boolean): Observable<Site[]> {
     this.setAuthHeader();
     return this.siteController.getAllSites(active);
+  }
+
+  createSite(siteDto: SiteDto): Observable<SiteDto> {
+    return this.siteController.newSite(siteDto as any);
+  }
+
+  updateSite(id: number, siteDto: SiteDto): Observable<SiteDto> {
+    return this.siteController.updateSite(id, siteDto as any);
   }
 }

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -65,6 +65,11 @@ export class UserService {
     return this.userControllerService.getAllUsers();
   }
 
+  getUsersForSite(siteId: number): Observable<Array<UserProfileDto>> {
+    this.setAuthHeader();
+    return this.userControllerService.getUsersForSite(siteId);
+  }
+
   // Normalized setAuthHeader method
   private setAuthHeader(): void {
     try {


### PR DESCRIPTION
1. Implemented user panel:

    - Pin admins on top
    - Add change password
    - Add deactivate user
    - Add calling new user form to add new users as admin

2. Implemented site / field panel:
    - Adding site
    - Updating site status
    - Adding Field
    - Updating / removing / adding maintenance dates

3. Added by-site user list for role 7 (site admin) as Site admin should not manage other site users
4. Binded to buttons creation of new sites, removing maintenance, etc
5. Added GobalExceptionHandler to expose errors to frontend - used only for Sessions definition - something to explore later. We only expose 400 and 409 errors to avoid so no authentication or other errors are exposed
             ---> Added the error message (coming from backend - wow) to not push heavy math logic on the frontend

6. Implemented workaround to set maintenance to null when passing 1970-01-01 as date when clicking cancelling
7. Fixed issue 'User form for site admin should load only admin site #105 while improving logic on invite users'

**The GlobalExceptionHandler (that was passing the error messages to the frontend) cause open-api / swagger to fail. With the help of AI:

1. Added a strongly typed DTO/record: ApiErrorResponse
2. Updated GlobalExceptionHandler to return ResponseEntity<ApiErrorResponse> instead of Map<String,Object>
3. Marked the advice as @Hidden so Springdoc won’t try to document/process it:
4. Kept it scoped to your controllers:
@RestControllerAdvice(basePackages = "lu.ephec.backend_projetdv2026.controller")**